### PR TITLE
#35 Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This is even more WIP than `react-three-renderer` itself! Literally unusable. Th
 - Wow, it was much easier than I thought.
 - Motivation was [this tweet by Dan](https://twitter.com/dan_abramov/status/852150540985401345) :)
 - [Lin Clark's talk on fiber](https://www.youtube.com/watch?v=ZCuYPiUIONs) helped a lot!
-- Still needed some reverse engineering but not even close to the amount necessary for `react-three-renderer`. 
+- Still needed some reverse engineering but not even close to the amount necessary for `react-three-renderer`.
   - Looked at how [react-ionize](https://github.com/mhink/react-ionize) does it
-  - Looked at how [react-dom does it](https://github.com/facebook/react/blob/master/src/renderers/dom/fiber/ReactDOMFiber.js)
+  - Looked at how [react-dom does it](https://github.com/facebook/react/blob/15-stable/src/renderers/dom/fiber/ReactDOMFiber.js)
 - It seems to be super fast (for this specific experiment, that does not mean that much though)
 - I &nbsp; :heart: &nbsp; fiber
 
@@ -22,7 +22,7 @@ This is even more WIP than `react-three-renderer` itself! Literally unusable. Th
 
 ## Wanna play around?
 - Clone repository
-- `> yarn` 
+- `> yarn`
 - `> yarn start`
 - Open http://localhost:8080
 - Look at react devtools


### PR DESCRIPTION
Fixes the react-dom url.  It appears my editor removed the whitespace from lines 10 and 25 as well 