### PR TITLE
Add cylinder geometry

### DIFF
--- a/src/core/renderer/hostDescriptors/descriptors/geometries/cylinderGeometry.ts
+++ b/src/core/renderer/hostDescriptors/descriptors/geometries/cylinderGeometry.ts
@@ -1,0 +1,61 @@
+import * as THREE from "three";
+import {CylinderGeometry} from "three";
+import {GeometryContainerType, GeometryWrapperBase} from "../../common/geometryBase";
+import {IThreeElementPropsBase} from "../../common/IReactThreeRendererElement";
+import {WrappedEntityDescriptor} from "../../common/ObjectWrapper";
+
+export interface ICylinderGeometryProps {
+  radiusTop?: number;
+  radiusBottom?: number;
+  height?: number;
+  radialSegments?: number;
+  heightSegments?: number;
+  openEnded?: boolean;
+  thetaStart?: number;
+  thetaLength?: number;
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      cylinderGeometry: IThreeElementPropsBase<THREE.CylinderGeometry> & ICylinderGeometryProps;
+    }
+  }
+}
+
+export class CylinderGeometryWrapper extends GeometryWrapperBase<ICylinderGeometryProps, CylinderGeometry> {
+  protected constructGeometry(props: ICylinderGeometryProps): CylinderGeometry {
+    return new CylinderGeometry(
+      props.radiusTop,
+      props.radiusBottom,
+      props.height,
+      props.radialSegments,
+      props.heightSegments,
+      props.openEnded,
+      props.thetaStart,
+      props.thetaLength
+    );
+  }
+}
+
+class CylinderGeometryDescriptor extends WrappedEntityDescriptor<CylinderGeometryWrapper,
+  ICylinderGeometryProps,
+  CylinderGeometry,
+  GeometryContainerType> {
+  constructor() {
+    super(CylinderGeometryWrapper, CylinderGeometry);
+
+    this.hasRemountProps(
+      "radiusTop",
+      "radiusBottom",
+      "height",
+      "radialSegments",
+      "heightSegments",
+      "openEnded",
+      "thetaStart",
+      "thetaLength"
+    );
+  }
+}
+
+export default CylinderGeometryDescriptor;


### PR DESCRIPTION
*dj khaled voice* anothuh one

Proof of concept'ed this on local by changing boxGeometry to cylinderGeometry & changed props accordingly in examples/src/index.tsx

also, while investigating the default height issue here - https://github.com/toxicFork/react-three-renderer-fiber/pull/46 - I found that between three js version 0.87 (r3r's version) and version 0.89 (current), the default height changed from 100 to 1.  no idea why it was ever 100. 