### PR TITLE
Add lathe geometry

### DIFF
--- a/src/core/renderer/hostDescriptors/descriptors/geometries/latheGeometry.ts
+++ b/src/core/renderer/hostDescriptors/descriptors/geometries/latheGeometry.ts
@@ -1,0 +1,49 @@
+import * as THREE from "three";
+import {LatheGeometry} from "three";
+import {GeometryContainerType, GeometryWrapperBase} from "../../common/geometryBase";
+import {IThreeElementPropsBase} from "../../common/IReactThreeRendererElement";
+import {WrappedEntityDescriptor} from "../../common/ObjectWrapper";
+
+export interface ILatheGeometryProps {
+  points: Array<THREE.Vector2>;
+  segments?: number;
+  phiStart?: number;
+  phiLength?: number;
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      latheGeometry: IThreeElementPropsBase<THREE.LatheGeometry> & ILatheGeometryProps;
+    }
+  }
+}
+
+export class LatheGeometryWrapper extends GeometryWrapperBase<ILatheGeometryProps, LatheGeometry> {
+  protected constructGeometry(props: ILatheGeometryProps): LatheGeometry {
+    return new LatheGeometry(
+      props.points as any,
+      props.segments,
+      props.phiStart,
+      props.phiLength
+    );
+  }
+}
+
+class LatheGeometryDescriptor extends WrappedEntityDescriptor<LatheGeometryWrapper,
+  ILatheGeometryProps,
+  LatheGeometry,
+  GeometryContainerType> {
+  constructor() {
+    super(LatheGeometryWrapper, LatheGeometry);
+
+    this.hasRemountProps(
+      "points",
+      "segments",
+      "phiStart",
+      "phiLength"
+    );
+  }
+}
+
+export default LatheGeometryDescriptor;


### PR DESCRIPTION
I'm having a strange issue here - notice on line 24, I have to convert the `points` array from an array of Vector2's to Vector3's.  According to the THREE.js docs, points is an array of Vector2.  However, if I remove line 24, I get a compiler error: 

```
ERROR in [at-loader] ./src/core/renderer/hostDescriptors/descriptors/geometries/latheGeometry.ts:25:7                                                                                
    TS2345: Argument of type 'Vector2[]' is not assignable to parameter of type 'Vector3[]'.                                                                                         
  Type 'Vector2' is not assignable to type 'Vector3'.                                                                                                                                
    Property 'z' is missing in type 'Vector2'. 
```

Do you have any insight into this?  With line 24 it works, but it's kind of hacky.  Also, changing the type from `Array<THREE.Vector2>` to  `Array<THREE.Vector3>` on line 8 results in the expected type error.

Let me know what you think.