### PR TITLE
Add step to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is even more WIP than `react-three-renderer` itself! Literally unusable. Th
 ## Wanna play around?
 - Clone repository
 - `> yarn`
+- `> cd examples && yarn && cd ..`
 - `> yarn start`
 - Open http://localhost:8080
 - Look at react devtools


### PR DESCRIPTION
Hey!  It's me again.  So I had to setup this project on a new machine and ran into problems when I followed the README steps.  Specifically, the 
```
<script src="node_modules/react/umd/react.development.js"></script>
<script src="node_modules/react-dom/umd/react-dom.development.js"></script>
```

lines in `examples/index.html` were breaking because it couldn't find the files.  This is because yarn doesn't install the dependencies for `examples` when you run yarn install from the root.  It's a small detail but cost me ~45 minutes of trying to find a bug in the webpack config or fiddling with the path in the `script src`.
